### PR TITLE
hook-template for tram-one hooks (and functions)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "tram-blueprints",
+  "version": "1.1.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
   "name": "tram-blueprints",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "tram-one templates for use with the blueprint-templates plugin",
-  "files": ["templates"],
+  "files": [
+    "templates"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Tram-One/tram-blueprints.git"

--- a/templates/tram-hook/__name__/__name__.js
+++ b/templates/tram-hook/__name__/__name__.js
@@ -1,0 +1,6 @@
+import { useState } from 'tram-one'
+
+export default () => {
+	const [value, setter] = useState(true)
+	return value
+}

--- a/templates/tram-hook/__name__/__name__.test.js
+++ b/templates/tram-hook/__name__/__name__.test.js
@@ -1,0 +1,7 @@
+import {{ name }} from './{{ name }}'
+
+describe('{{ name }}', () => {
+	it('should return true by default', () => {
+		expect({{ name }}()).toBe(true)
+	})
+})

--- a/templates/tram-hook/__name__/index.js
+++ b/templates/tram-hook/__name__/index.js
@@ -1,0 +1,1 @@
+export { default } from './{{ name }}'


### PR DESCRIPTION
## Summary

This PR enables another template that should make creating new custom hooks (or even basic functions) easier by providing a default `index.js`, `test.js` and source file in a named folder. 